### PR TITLE
Update Discord button+link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > 🤖 **We're spinning up a new ngrok community on Discord!** Come flex your ingress, brainstorm some new Traffic Policy brilliance, and hang with the engineers who built ngrok from the ground-up.
 > 
-> ![Get in here](https://img.shields.io/discord/1362500814312182032?label=Get%20in%20here&logo=discord&style=flat)
+> ![Get in here](https://img.shields.io/discord/1362500814312182032?label=Get%20in%20here&logo=discord&style=flat&link=https://ngrok.com/discord)
 
 # ngrok Community Discussions
 


### PR DESCRIPTION
A new user to Discord pointed out that the Discord button, while showing the right number of active users, doesn't have a link target, which makes it quite difficult to find.